### PR TITLE
"clear_interval" functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Release 1.1.0 (2021-06-14)
+- began with changelog
+- added `clear_interval`-function to clear intervals, similar to javascript
+- `set_interval` now returns an integer (ID) -> used as value for clear_interval
+ 
+# Releases 1.0.1, 1.0.2, 1.0.3 (2021-05-17)
+- README updates
+- text fixes
+# Release 1.0.0 (2021-05-17)
+- initial release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ documentation = "https://docs.rs/tokio-js-set-interval"
 
 [dependencies]
 tokio = { version = "1.6.0", features = ["time"] }
+lazy_static = "1.4.0"
 
 [dev-dependencies]
 tokio = { version = "1.6.0", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ Allows you to use `setInterval(callback, ms)` and
 `setTimeout(callback, ms)` as in Javascript inside a `tokio` runtime.
 For this, it offers the macros `set_interval!(callback, ms)` and `set_timeout!(callback, ms)`.
 """
-version = "1.0.3"
+version = "1.1.0"
 edition = "2018"
 authors = ["Philipp Schuster <phip1611@gmail.com>"]
 keywords = ["tokio", "set-interval", "interval", "set-timeout", "timeout"]
@@ -19,8 +19,8 @@ documentation = "https://docs.rs/tokio-js-set-interval"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tokio = { version = "1.6.0", features = ["time"] }
+tokio = { version = "1.6.1", features = ["time"] }
 lazy_static = "1.4.0"
 
 [dev-dependencies]
-tokio = { version = "1.6.0", features = ["full"] }
+tokio = { version = "1.6.1", features = ["full"] }

--- a/README.md
+++ b/README.md
@@ -15,13 +15,16 @@ tokio-js-set-interval = "<latest-version>"
 **code.rs**
 ```rust
 use std::time::Duration;
-use tokio_js_set_interval::{set_interval, set_timeout};
+use tokio_js_set_interval::{set_interval, set_timeout, clear_interval};
 
 #[tokio::main]
 async fn main() {
     set_timeout!(println!("hello from timeout"), 25);
     set_interval!(println!("hello from interval"), 10);
-
+    // you can clear intervals if you want
+    let id = set_interval!(println!("hello from interval"), 10);
+    clear_interval(id);
+    
     // give enough time before tokios runtime exits
     tokio::time::sleep(Duration::from_millis(40)).await;
 }

--- a/README.md
+++ b/README.md
@@ -48,11 +48,3 @@ I over-engineered them a little to learn more about macros.
 Version 1.0.0 is developed with:
  * `tokio` @ 1.6.0 (but should also work with 1.0.0)
  * `rustc` @ 1.52.1 (but should also work with 1.45.2)
-
-
-## Changelog
-- Releases 1.0.1, 1.0.2, 1.0.3 (2021-05-17)
-  - README updates
-  - text fixes
-- Release 1.0.0 (2021-05-17)
-    - initial release

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -1,11 +1,14 @@
 use std::time::Duration;
-use tokio_js_set_interval::{set_interval, set_timeout};
+use tokio_js_set_interval::{set_interval, set_timeout, clear_interval};
 
 #[tokio::main]
 async fn main() {
     set_timeout!(println!("hello from timeout"), 25);
     set_interval!(println!("hello from interval"), 10);
+    let id = set_interval!(println!("hello from interval that will be cleared shortly"), 5);
 
     // give enough time before tokios runtime exits
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    clear_interval(id);
     tokio::time::sleep(Duration::from_millis(40)).await;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,11 +48,12 @@ SOFTWARE.
 //!  * `tokio` @ 1.6.0 (but should also work with 1.0.0)
 //!  * `rustc` @ 1.52.1 (but should also work with 1.45.2)
 
-use std::collections::BTreeMap;
+use std::collections::HashSet;
 use std::sync::atomic::AtomicU64;
+use std::sync::Mutex;
+
 use lazy_static::lazy_static;
 use tokio::time::Duration;
-use std::sync::Mutex;
 
 /// **INTERNAL** Use macro [`set_timeout`] instead!
 ///
@@ -63,28 +64,30 @@ pub async fn _set_timeout(f: impl Fn(), ms: u64) {
     f();
 }
 
+/// **INTERNAL** Used to manage intervals created by macro [`set_interval`]!
+/// Helps to assign unique IDs to intervals and stop them.
 pub struct IntervalManager {
+    /// Monotonic incrementing counter from 0 to max value used for interval IDs.
     pub counter: AtomicU64,
-    pub continue_map: Mutex<BTreeMap<u64, bool>>,
+    /// Contains only the IDs of dispatched and not cleared intervals.
+    pub running_intervals: Mutex<HashSet<u64>>,
 }
 
 lazy_static! {
+    /// **INTERNAL** Used to manage intervals created by macro [`set_interval`]!
     pub static ref INTERVAL_MANAGER: IntervalManager = IntervalManager {
         counter: AtomicU64::new(0),
-        continue_map: Mutex::new(BTreeMap::new())
+        running_intervals: Mutex::new(HashSet::new())
     };
 }
 
-
-/// **INTERNAL** Use macro [`set_interval`] instead!
-///
 /// Creates a future that glues the tokio interval function together with
-/// the provided callback.
-pub async fn _set_interval(f: impl Fn(), ms: u64, id: u64) {
+/// the provided callback. Helper function for [`_set_interval_spawn`].
+async fn _set_interval(f: impl Fn() + Send + 'static, ms: u64, id: u64) {
     // own scope -> early drop lock
     {
-        let mut map = INTERVAL_MANAGER.continue_map.lock().unwrap();
-        map.insert(id, true);
+        let mut map = INTERVAL_MANAGER.running_intervals.lock().unwrap();
+        map.insert(id);
     }
 
     let mut int = tokio::time::interval(Duration::from_millis(ms));
@@ -98,13 +101,35 @@ pub async fn _set_interval(f: impl Fn(), ms: u64, id: u64) {
     // when the tokio runtime gets dropped.
     loop {
         int.tick().await;
-        f();
 
-        // break if the interval property for the given id is set to "false"
-        let map = INTERVAL_MANAGER.continue_map.lock().unwrap();
-        if !map.get(&id).unwrap() {
+        // breaks the loop
+        let map = INTERVAL_MANAGER.running_intervals.lock().unwrap();
+        if !map.contains(&id) {
             break;
         }
+
+        f();
+    }
+}
+
+/// **INTERNAL** Use macro [`set_interval`] instead!
+///
+/// Acquires a new ID, creates an interval future and returns the ID. The future gets
+/// dispatched as tokio task.
+pub fn _set_interval_spawn(f: impl Fn() + Send + 'static, ms: u64) -> u64 {
+    let id = INTERVAL_MANAGER
+        .counter
+        .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+    tokio::spawn(_set_interval(f, ms, id));
+    id
+}
+
+/// Clears an interval that was created via [`set_interval!`]. You have to pass
+/// the unique numeric ID as parameter. Throws no error, if the ID is unknown.
+pub fn clear_interval(id: u64) {
+    let mut set = INTERVAL_MANAGER.running_intervals.lock().unwrap();
+    if set.contains(&id) {
+        set.remove(&id);
     }
 }
 
@@ -169,10 +194,8 @@ macro_rules! set_timeout {
 /// You don't get a handle to manually wait for it, you must ensure, that the tokio
 /// runtime lives long enough.
 ///
-/// The interval is not stoppable (unless the application stops). Strictly speaking, there
-/// should be a way to clear an interval, similar to javascript. But because this library is
-/// mainly for educational reasons and for "low priority indefinetely running background tasks",
-/// this is not implemented yet. If you need it, create an issue or a PR.
+/// The macro returns an numeric ID. Similar to Javascript, you can use thie ID to
+/// clear/stop intervals with [`clear_interval`].
 ///
 /// # Parameters
 /// * `#1` expression, closure-expression, block or identifier (which points to a closure).
@@ -187,6 +210,8 @@ macro_rules! set_timeout {
 /// #[tokio::main]
 /// async fn main() {
 ///     set_interval!(println!("hello1"), 50);
+///     // If you want to clear the interval later: save the ID
+///     // let id = set_interval!(println!("hello1"), 50);
 ///     println!("hello2");
 ///     // prevent that tokios runtime gets dropped too early
 ///     // "hello1" should get printed 2 times (50*2 == 100 < 120)
@@ -197,39 +222,16 @@ macro_rules! set_timeout {
 macro_rules! set_interval {
     // match for identifier, i.e. a closure, that is behind a variable
     ($cb:ident, $ms:literal) => {
-        let id = ($crate::INTERVAL_MANAGER).counter.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-        tokio::spawn(
-            $crate::_set_interval(
-                $cb,
-                $ms,
-                id,
-            )
-        );
-        id
+        // not so nice, need to wrap the identifier in another closure
+        $crate::set_interval!(move || $cb(), $ms)
     };
     // match for direct closure expression
     (|| $cb:expr, $ms:literal) => {
-        let id = ($crate::INTERVAL_MANAGER).counter.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-        tokio::spawn(
-            $crate::_set_interval(
-                || $cb,
-                $ms,
-                id,
-            )
-        );
-        id
+        $crate::_set_interval_spawn(|| $cb, $ms)
     };
     // match for direct move closure expression
     (move || $cb:expr, $ms:literal) => {
-        let id = ($crate::INTERVAL_MANAGER).counter.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-        tokio::spawn(
-            $crate::_set_interval(
-                move || $cb,
-                $ms,
-                id,
-            )
-        );
-        id
+        $crate::_set_interval_spawn(move || $cb, $ms)
     };
     // match for expr, like `set_interval!(println!())`
     ($cb:expr, $ms:literal) => {
@@ -241,25 +243,12 @@ macro_rules! set_interval {
     };
 }
 
-pub fn clear_interval(id: u64) {
-    let mut map = INTERVAL_MANAGER.continue_map.lock().unwrap();
-    match map.get_mut(&id) {
-        None => {}
-        Some(continue_interval) => {*continue_interval = false}
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
     use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::Arc;
 
     use super::*;
-
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
-    }
 
     #[tokio::test]
     async fn test_set_timeout_macro_all_argument_variants_builds() {
@@ -309,7 +298,10 @@ mod tests {
         println!("hello3");
         set_timeout!(println!("hello4"), 0);
         println!("hello5");
-        // give the timeout enough execution time
+
+        // give enough execution time, before tokio gets dropped
+        // two tokio sleeps: timeouts will usually get scheduled in between
+        tokio::time::sleep(Duration::from_millis(1)).await;
         tokio::time::sleep(Duration::from_millis(1)).await;
     }
 
@@ -318,9 +310,11 @@ mod tests {
     /// be executed manually.
     #[tokio::test]
     async fn test_set_interval_visual() {
-        set_interval!(println!("should be printed 3 times"), 2);
+        let id = set_interval!(println!("should be printed 3 times"), 50);
         // give the timeout enough execution time
-        tokio::time::sleep(Duration::from_millis(7)).await;
+        tokio::time::sleep(Duration::from_millis(151)).await;
+        tokio::time::sleep(Duration::from_millis(0)).await;
+        println!("interval id is: {}", id);
     }
 
     #[tokio::test]

--- a/test_and_build.sh
+++ b/test_and_build.sh
@@ -2,6 +2,10 @@
 
 cargo build --all-targets --all --examples
 cargo test
+cargo run --example example-with-move
+cargo run --example interval-and-timeout-like-in-javascript
+cargo run --example macro-possible-arguments
+cargo run --example minimal
 
 cd "external-example" || exit;
 cargo build


### PR DESCRIPTION
This PR introduces a `clear_interval`-function, that behaves similar to Javascripts functionality to clear an interval. `set_interval!()` now returns an id.

Example:

```rust
use std::time::Duration;
use tokio_js_set_interval::{set_interval, set_timeout, clear_interval};

#[tokio::main]
async fn main() {
    set_timeout!(println!("hello from timeout"), 25);
    set_interval!(println!("hello from interval"), 10);
    // you can clear intervals if you want
    let id = set_interval!(println!("hello from interval"), 10);
    clear_interval(id);
    
    // give enough time before tokios runtime exits
    tokio::time::sleep(Duration::from_millis(40)).await;
}
```