### PR TITLE
Add `set_interval_async!` and `set_timeout_async!` (v1.2.0)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,7 @@ jobs:
         rust:
           - stable
           - nightly
-          - 1.52.1 # MSVR
+          - 1.49.0 # MSVR
     steps:
       - uses: actions/checkout@v2
       # Important preparation step: override the latest default Rust version in GitHub CI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # 1.2.0 (2022-09-04)
 - Added the `set_timeout_async!` macro. It consumes an identifier that is an async function.
+  Async closures are currently not supported as this required an unstable async closure feature.
+- Added the `set_interval_async!` macro. It consumes an identifier that is an async function.
   Async functions are currently not supported as this required an unstable async closure feature.
 - small fix in `set_interval!`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,7 @@
 # 1.2.0 (2022-09-04)
-- Added the `set_timeout_async!` macro. It consumes an identifier that is an async function.
-  Async closures are currently not supported as this required an unstable async closure feature.
-- Added the `set_interval_async!` macro. It consumes an identifier that is an async function.
-  Async functions are currently not supported as this required an unstable async closure feature.
+- Added the `set_timeout_async!` macro. It accepts futures either by expression or by identifier.
+- Added the `set_interval_async!` macro. It accepts a function that produces futures by identifier
+  or by expression.
 - small fix in `set_interval!`
 
 # 1.1.1 (2022-05-02)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 1.2.0 (2022-09-04)
 - Added the `set_timeout_async!` macro. It consumes an identifier that is an async function.
   Async functions are currently not supported as this required an unstable async closure feature.
+- small fix in `set_interval!`
 
 # 1.1.1 (2022-05-02)
 - small internal improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
-# 1.2.0 (2022-09-04)
+# 1.2.0 (2022-09-12)
 - Added the `set_timeout_async!` macro. It accepts futures either by expression or by identifier.
 - Added the `set_interval_async!` macro. It accepts a function that produces futures by identifier
   or by expression.
+- examples for the new macros can be found in `examples/macro-possible-arguments.rs`
 - small fix in `set_interval!`
+- FYI: MSRV is `1.49.0` (with `tokio @ 1.21.0`). Minimum supported tokio version is still `1.0.x`.
 
 # 1.1.1 (2022-05-02)
 - small internal improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.2.0 (2022-09-04)
+- Added the `set_timeout_async!` macro. It consumes an identifier that is an async function.
+  Async functions are currently not supported as this required an unstable async closure feature.
+
 # 1.1.1 (2022-05-02)
 - small internal improvements
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ Allows you to use `setInterval(callback, ms)` and
 `setTimeout(callback, ms)` as in Javascript inside a `tokio` runtime.
 For this, it offers the macros `set_interval!(callback, ms)` and `set_timeout!(callback, ms)`.
 """
-version = "1.1.1"
+version = "1.2.0"
 edition = "2018"
 authors = ["Philipp Schuster <phip1611@gmail.com>"]
 keywords = ["tokio", "set-interval", "interval", "set-timeout", "timeout"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "tokio-js-set-interval"
 description = """
 Allows you to use `setInterval(callback, ms)` and
 `setTimeout(callback, ms)` as in Javascript inside a `tokio` runtime.
-For this, it offers the macros `set_interval!(callback, ms)` and `set_timeout!(callback, ms)`.
+The library provides the macros `set_interval!(callback, ms)` and `set_timeout!(callback, ms)`.
 """
 version = "1.2.0"
 edition = "2018"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,11 @@
 
 The crate `tokio-js-set-interval` allows you to use `setInterval(callback, ms)` and
 `setTimeout(callback, ms)` as in Javascript inside a **`tokio` runtime (https://tokio.rs/)**.
-For this, it offers the macros `set_interval!(callback, ms)` and `set_timeout!(callback, ms)`.
+The library provides the macros:
+- `set_interval!(callback, ms)`,
+- `set_interval_async!(async_callback, ms)`,
+- `set_timeout!(callback, ms)`,
+- and `set_timeout_async!(async_callback, ms)`.
 
 ## How to use
 **Cargo.toml**
@@ -24,7 +28,7 @@ async fn main() {
     // you can clear intervals if you want
     let id = set_interval!(println!("hello from interval"), 10);
     clear_interval(id);
-    
+
     // give enough time before tokios runtime exits
     tokio::time::sleep(Duration::from_millis(40)).await;
 }
@@ -34,10 +38,10 @@ async fn main() {
 They behave similar to their Javascript counterparts, with a few exceptions:
 
  * They only get executed if the `tokio` runtime lives long enough.
- * on order to compile, the callback must return the union type, i.e. `()`
- * => all actions must be done via side effects
+ * on order to compile, the callback must return the union type, i.e. `()` \
+   => all actions must be done via side effects
  * again, there is **NO GUARANTEE** that the tasks will get executed \
-   (--> but useful/convenient for low priority background tasks and for the learning effect of course)
+   (=> but useful/convenient for low priority background tasks and for the learning effect of course)
 
 ## Trivia
 ⚠ I'm not an expert in `tokio` (or async/await/futures in Rust in general) and I don't

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The crate `tokio-js-set-interval` allows you to use `setInterval(callback, ms)` 
 `setTimeout(callback, ms)` as in Javascript inside a **`tokio` runtime (https://tokio.rs/)**.
 The library provides the macros:
 - `set_interval!(callback, ms)`,
-- `set_interval_async!(async_callback, ms)`,
+- `set_interval_async!(future, ms)`,
 - `set_timeout!(callback, ms)`,
 - and `set_timeout_async!(async_callback, ms)`.
 
@@ -41,17 +41,19 @@ They behave similar to their Javascript counterparts, with a few exceptions:
  * on order to compile, the callback must return the union type, i.e. `()` \
    => all actions must be done via side effects
  * again, there is **NO GUARANTEE** that the tasks will get executed \
-   (=> but useful/convenient for low priority background tasks and for the learning effect of course)
+   (=> however useful and convenient for low priority background tasks and for the learning effect of course)
 
 ## Trivia
-⚠ I'm not an expert in `tokio` (or async/await/futures in Rust in general) and I don't
-  know if this follows best practises. But it helped me to understand how `tokio` works.
-  I hope it may be helpful to some of you too. ⚠
+I'm not an expert in `tokio` (or async/await/futures in Rust in general) and I don't
+know if this follows best practises. But it helped me to understand how `tokio` works.
+I hope it may be helpful to some of you too.
 
-The functionality itself is really simple. The biggest part are the convenient macros.
-I over-engineered them a little to learn more about macros.
+The functionality behind is rather simple. However, it took me some time to figure out what kind of
+input the macros should accept and how the generic arguments of the functions behind the macros
+need to be structured. Especially the `*_async!()` versions of the macros were quite complicated
+during the development.
 
-## Compatibility
-Version 1.0.0 is developed with:
- * `tokio` @ 1.6.0 (but should also work with 1.0.0)
- * `rustc` @ 1.52.1 (but should also work with 1.45.2)
+## Compatibility & MSRV
+Version 1.2.0 is developed with `tokio@1.21.0` and `rust@1.63.0`. The minimum supported `tokio`
+version is `1.0.x` and the MSRV depends on the `tokio` version. For the latest tokio version,
+the `MSRV` is `1.49.0`.

--- a/examples/macro-possible-arguments.rs
+++ b/examples/macro-possible-arguments.rs
@@ -49,7 +49,7 @@ async fn main() {
     let future = async_foo();
     // macro takes future by identifier
     set_timeout_async!(future, 1);
-    // macro takes a expression that returns a future
+    // macro takes an expression that returns a future
     set_timeout_async!(async_foo(), 1);
     // macro takes block
     set_timeout_async!(async { println!("set_timeout_async 2") }, 1);
@@ -60,12 +60,12 @@ async fn main() {
     // ######################################################################
     // set_interval_async
 
-    // macro takes identifiers (which must point to a future-producing closure)
     async fn async_foo2() {
         println!("set_interval_async 1");
     }
+    // macro takes identifier (that must point to a future-producing function)
     set_interval_async!(async_foo2, 42);
-    // macro takes block
+    // macro takes block with async inner block
     set_interval_async!(
         {
             async {
@@ -77,7 +77,7 @@ async fn main() {
     // macro takes a closure that produces a future
     set_interval_async!(
         || {
-            async move {
+            async {
                 println!("set_interval_async 3");
             }
         },

--- a/examples/macro-possible-arguments.rs
+++ b/examples/macro-possible-arguments.rs
@@ -1,19 +1,97 @@
 use tokio::time::Duration;
-use tokio_js_set_interval::set_timeout;
+use tokio_js_set_interval::{set_interval, set_interval_async, set_timeout, set_timeout_async};
 
 #[tokio::main]
 async fn main() {
+    // ######################################################################
+    // set_timeout
+
     // macro takes expression
-    set_timeout!(println!("hello1"), 4);
+    set_timeout!(println!("set_timeout 1"), 4);
     // macro takes block
-    set_timeout!({ println!("hello2") }, 3);
+    set_timeout!({ println!("set_timeout 2") }, 3);
     // macro takes direct closure expressions
-    set_timeout!(|| println!("hello3"), 2);
+    set_timeout!(|| println!("set_timeout 3"), 2);
     // macro takes direct move closure expressions
-    set_timeout!(move || println!("hello4"), 2);
+    set_timeout!(move || println!("set_timeout 4"), 2);
     // macro takes identifiers (which must point to closures)
-    let closure = || println!("hello5");
+    let closure = || println!("set_timeout 5");
     set_timeout!(closure, 1);
+
+    // give enough time before tokios runtime exits
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // ######################################################################
+    // set_interval
+
+    // macro takes expression
+    set_interval!(println!("set_interval 1"), 42);
+    // macro takes block
+    set_interval!({ println!("set_interval 2") }, 42);
+    // macro takes direct closure expressions
+    set_interval!(|| println!("set_interval 3"), 42);
+    // macro takes direct move closure expressions
+    set_interval!(move || println!("set_interval 4"), 42);
+    // macro takes identifiers (which must point to closures)
+    let closure = || println!("set_interval 5");
+    set_interval!(closure, 42);
+
+    // give enough time before tokios runtime exits
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // ######################################################################
+    // set_timeout_async
+
+    // macro takes identifiers (which must point to closures)
+    async fn async_foo() {
+        println!("set_timeout_async 1");
+    }
+    let future = async_foo();
+    // macro takes future by identifier
+    set_timeout_async!(future, 1);
+    // macro takes a expression that returns a future
+    set_timeout_async!(async_foo(), 1);
+    // macro takes block
+    set_timeout_async!(async { println!("set_timeout_async 2") }, 1);
+
+    // give enough time before tokios runtime exits
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // ######################################################################
+    // set_interval_async
+
+    // macro takes identifiers (which must point to a future-producing closure)
+    async fn async_foo2() {
+        println!("set_interval_async 1");
+    }
+    set_interval_async!(async_foo2, 42);
+    // macro takes block
+    set_interval_async!(
+        {
+            async {
+                println!("set_interval_async 2");
+            }
+        },
+        42
+    );
+    // macro takes a closure that produces a future
+    set_interval_async!(
+        || {
+            async move {
+                println!("set_interval_async 3");
+            }
+        },
+        42
+    );
+    // macro takes a move closure that produces a future
+    set_interval_async!(
+        move || {
+            async move {
+                println!("set_interval_async 4");
+            }
+        },
+        42
+    );
 
     // give enough time before tokios runtime exits
     tokio::time::sleep(Duration::from_millis(100)).await;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,10 +111,13 @@ async fn _set_interval(f: impl Fn() + Send + 'static, ms: u64, id: u64) {
     loop {
         int.tick().await;
 
-        // breaks the loop
-        let map = INTERVAL_MANAGER.running_intervals.lock().unwrap();
-        if !map.contains(&id) {
-            break;
+        // - breaks the loop if the interval war cleared.
+        // - dedicated block to drop lock early
+        {
+            let map = INTERVAL_MANAGER.running_intervals.lock().unwrap();
+            if !map.contains(&id) {
+                break;
+            }
         }
 
         f();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,16 +24,20 @@ SOFTWARE.
 
 //! The crate `tokio-js-set-interval` allows you to use `setInterval(callback, ms)` and
 //! `setTimeout(callback, ms)` as in Javascript inside a `tokio` runtime (<https://tokio.rs/>).
-//! For this, it offers the macros `set_interval!(callback, ms)` and `set_timeout!(callback, ms)`.
+//! The library provides the macros:
+//! - `set_interval!(callback, ms)`,
+//! - `set_interval_async!(async_callback, ms)`,
+//! - `set_timeout!(callback, ms)`,
+//! - and `set_timeout_async!(async_callback, ms)`.
 //!
 //! ## Restrictions
 //! They behave similar to their Javascript counterparts, with a few exceptions:
 //!
 //!  * They only get executed if the `tokio` runtime lives long enough.
-//!  * on order to compile, the callback must return the union type, i.e. `()`
-//!  * => all actions must be done via side effects
+//!  * on order to compile, the callback must return the union type, i.e. `()` \
+//!    => all actions must be done via side effects
 //!  * ⚠ again, there is **NO GUARANTEE** that the tasks will get executed \
-//!    (--> but useful/convenient for low priority background tasks and for the learning effect of course) ⚠
+//!    (=> but useful/convenient for low priority background tasks and for the learning effect of course) ⚠
 //!
 //! ## Trivia
 //! ⚠ I'm not an expert in `tokio` (or async/await/futures in Rust in general) and I don't


### PR DESCRIPTION
- bumps to version 1.2.0
- Added the `set_timeout_async!` macro. It accepts futures either by expression or by identifier.
- Added the `set_interval_async!` macro. It accepts a function that produces futures by identifier
  or by expression.
- small fix in `set_interval!`